### PR TITLE
*: store persists between builds, added commands to interact with store

### DIFF
--- a/acbuild/store.go
+++ b/acbuild/store.go
@@ -1,0 +1,126 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	flagStoreFetchInsecure = false
+	cmdStore               = &cobra.Command{
+		Use:   "store [command]",
+		Short: "Manage images in acbuild's store",
+	}
+	cmdStoreFetch = &cobra.Command{
+		Use:     "fetch IMAGE",
+		Short:   "fetches and renders an image into the store",
+		Example: "acbuild store fetch example.com/worker:v1.2.3",
+		Run:     runWrapper(runStoreFetch),
+	}
+	cmdStoreList = &cobra.Command{
+		Use:     "list",
+		Short:   "List all images in the store",
+		Example: "acbuild store list",
+		Run:     runWrapper(runStoreList),
+	}
+	cmdStoreClear = &cobra.Command{
+		Use:     "clear",
+		Short:   "Deletes all images in the store",
+		Example: "acbuild store clear",
+		Run:     runWrapper(runStoreClear),
+	}
+	cmdStoreDelete = &cobra.Command{
+		Use:     "rm IMAGE",
+		Short:   "Removes an image from the store",
+		Example: "acbuild store rm example.com/worker:v1.2.3",
+		Run:     runWrapper(runStoreDelete),
+	}
+)
+
+func init() {
+	cmdAcbuild.AddCommand(cmdStore)
+	cmdStore.AddCommand(cmdStoreList)
+	cmdStore.AddCommand(cmdStoreClear)
+	cmdStore.AddCommand(cmdStoreDelete)
+	cmdStore.AddCommand(cmdStoreFetch)
+
+	cmdStoreFetch.Flags().BoolVar(&flagStoreFetchInsecure, "insecure", false, "Allows fetching dependencies over http")
+}
+
+func runStoreFetch(cmd *cobra.Command, args []string) (exit int) {
+	if len(args) != 1 {
+		cmd.Usage()
+		return 1
+	}
+	err := newACBuild().FetchImage(args[0], flagStoreFetchInsecure)
+	if err != nil {
+		stderr("store fetch: %v", err)
+		return 1
+	}
+	return 0
+}
+
+func runStoreList(cmd *cobra.Command, args []string) (exit int) {
+	if len(args) > 0 {
+		cmd.Usage()
+		return 1
+	}
+
+	images, err := newACBuild().GetImagesInStore()
+	if err != nil {
+		stderr("store list: %v", err)
+		return getErrorCode(err)
+	}
+
+	if len(images) == 0 {
+		stderr("store list: no images in store")
+	}
+
+	for _, image := range images {
+		version, ok := image.Labels.Get("version")
+		if !ok {
+			version = "latest"
+		}
+		stdout(image.Name.String() + ":" + version)
+	}
+	return 0
+}
+
+func runStoreClear(cmd *cobra.Command, args []string) (exit int) {
+	if len(args) > 0 {
+		cmd.Usage()
+		return 1
+	}
+	err := newACBuild().ClearStore()
+	if err != nil {
+		stderr("store clear: %v", err)
+		return getErrorCode(err)
+	}
+	return 0
+}
+
+func runStoreDelete(cmd *cobra.Command, args []string) (exit int) {
+	if len(args) != 1 {
+		cmd.Usage()
+		return 1
+	}
+	err := newACBuild().DeleteImage(args[0])
+	if err != nil {
+		stderr("store rm: %v", err)
+		return 1
+	}
+	return 0
+}

--- a/lib/common.go
+++ b/lib/common.go
@@ -24,6 +24,7 @@ import (
 )
 
 const defaultWorkPath = ".acbuild"
+const defaultStoreDir = "/var/lib/acbuild"
 
 var (
 	// ErrNotFound is returned when acbuild is asked to remove an element from a
@@ -61,13 +62,19 @@ type ACBuild struct {
 
 // NewACBuild returns a new ACBuild struct with sane defaults for all of the
 // different paths
-func NewACBuild(cwd string, debug bool) *ACBuild {
+func NewACBuild(cwd, storeDir string, debug bool) *ACBuild {
+	var storePath string
+	if storeDir != "" {
+		storePath = storeDir
+	} else {
+		storePath = defaultStoreDir
+	}
 	return &ACBuild{
 		ContextPath:          path.Join(cwd, defaultWorkPath),
 		LockPath:             path.Join(cwd, defaultWorkPath, "lock"),
 		CurrentACIPath:       path.Join(cwd, defaultWorkPath, "currentaci"),
-		DepStoreTarPath:      path.Join(cwd, defaultWorkPath, "depstore-tar"),
-		DepStoreExpandedPath: path.Join(cwd, defaultWorkPath, "depstore-expanded"),
+		DepStoreTarPath:      path.Join(storePath, "depstore-tar"),
+		DepStoreExpandedPath: path.Join(storePath, "depstore-expanded"),
 		OverlayTargetPath:    path.Join(cwd, defaultWorkPath, "target"),
 		OverlayWorkPath:      path.Join(cwd, defaultWorkPath, "work"),
 		Debug:                debug,

--- a/lib/run.go
+++ b/lib/run.go
@@ -80,14 +80,6 @@ func (a *ACBuild) Run(cmd []string, workingDir string, insecure bool, runEngine 
 		return err
 	}
 	defer os.RemoveAll(a.OverlayWorkPath)
-	err = os.MkdirAll(a.DepStoreExpandedPath, 0755)
-	if err != nil {
-		return err
-	}
-	err = os.MkdirAll(a.DepStoreTarPath, 0755)
-	if err != nil {
-		return err
-	}
 
 	man, err := util.GetManifest(a.CurrentACIPath)
 	if err != nil {

--- a/lib/store.go
+++ b/lib/store.go
@@ -1,0 +1,114 @@
+// Copyright 2016 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lib
+
+import (
+	"os"
+	"strings"
+
+	"github.com/appc/spec/schema"
+	"github.com/appc/spec/schema/types"
+
+	"github.com/appc/acbuild/registry"
+)
+
+// FetchImage will fetch an image represented by imageName into acbuild's
+// store.
+func (a *ACBuild) FetchImage(imageName string, insecure bool) error {
+	reg := registry.Registry{
+		DepStoreTarPath:      a.DepStoreTarPath,
+		DepStoreExpandedPath: a.DepStoreExpandedPath,
+		Insecure:             insecure,
+		Debug:                a.Debug,
+	}
+
+	name, labels, err := stringToNameAndLabels(imageName)
+	if err != nil {
+		return err
+	}
+
+	return reg.FetchAndRender(*name, labels, 0)
+}
+
+// GetImagesInStore will return a list of manifests for each image currently in
+// acbuild's store.
+func (a *ACBuild) GetImagesInStore() ([]*schema.ImageManifest, error) {
+	reg := registry.Registry{
+		DepStoreTarPath:      a.DepStoreTarPath,
+		DepStoreExpandedPath: a.DepStoreExpandedPath,
+	}
+	keys, err := reg.GetAllACIs()
+	if err != nil {
+		return nil, err
+	}
+	manifests := make([]*schema.ImageManifest, len(keys))
+	for i, key := range keys {
+		manifest, err := reg.GetImageManifest(key)
+		if err != nil {
+			return nil, err
+		}
+		manifests[i] = manifest
+	}
+	return manifests, nil
+}
+
+// ClearStore will empty acbuild's store by deleting it.
+func (a *ACBuild) ClearStore() error {
+	err := os.RemoveAll(a.DepStoreTarPath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	err = os.RemoveAll(a.DepStoreExpandedPath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// DeleteImage will delete a single image, represented by imageName, from
+// acbuild's store.
+func (a *ACBuild) DeleteImage(imageName string) error {
+	reg := registry.Registry{
+		DepStoreTarPath:      a.DepStoreTarPath,
+		DepStoreExpandedPath: a.DepStoreExpandedPath,
+	}
+
+	name, labels, err := stringToNameAndLabels(imageName)
+	if err != nil {
+		return err
+	}
+
+	key, err := reg.GetACI(*name, labels)
+	if err != nil {
+		return err
+	}
+	return reg.DeleteACI(key)
+}
+
+func stringToNameAndLabels(str string) (*types.ACIdentifier, types.Labels, error) {
+	tokens := strings.SplitN(str, ":", 2)
+	name, err := types.NewACIdentifier(tokens[0])
+	if err != nil {
+		return nil, nil, err
+	}
+	var labels types.Labels
+	if len(tokens) > 1 {
+		labels = append(labels, types.Label{
+			Name:  *types.MustACIdentifier("version"),
+			Value: tokens[1],
+		})
+	}
+	return name, labels, err
+}

--- a/registry/fetch.go
+++ b/registry/fetch.go
@@ -46,6 +46,14 @@ func (r Registry) tmpuncompressedpath() string {
 	return path.Join(r.DepStoreTarPath, "tmp.uncompressed.aci")
 }
 
+func (r Registry) ensureStoreInitialized() error {
+	err := os.MkdirAll(r.DepStoreTarPath, 0755)
+	if err != nil {
+		return err
+	}
+	return os.MkdirAll(r.DepStoreExpandedPath, 0755)
+}
+
 // Fetch will download the given image, and optionally its dependencies, into
 // r.DepStoreTarPath
 func (r Registry) Fetch(imagename types.ACIdentifier, labels types.Labels, size uint, fetchDeps bool) error {
@@ -64,6 +72,7 @@ func (r Registry) Fetch(imagename types.ACIdentifier, labels types.Labels, size 
 // they have not been fetched yet, and will then render them on to the
 // filesystem if they have not been rendered yet.
 func (r Registry) FetchAndRender(imagename types.ACIdentifier, labels types.Labels, size uint) error {
+	r.ensureStoreInitialized()
 	err := r.Fetch(imagename, labels, size, true)
 	if err != nil {
 		return err

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -128,3 +128,29 @@ nextkey:
 	}
 	return "", ErrNotFound
 }
+
+// GetAllACIs returns a key for every image in the registry.
+func (r Registry) GetAllACIs() ([]string, error) {
+	files, err := ioutil.ReadDir(r.DepStoreExpandedPath)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	keys := make([]string, len(files))
+	for i, f := range files {
+		keys[i] = f.Name()
+	}
+	return keys, nil
+}
+
+func (r Registry) DeleteACI(key string) error {
+	for _, thingToDelete := range []string{
+		path.Join(r.DepStoreExpandedPath, key),
+		path.Join(r.DepStoreTarPath, key),
+	} {
+		err := os.RemoveAll(thingToDelete)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This commit modifies acbuild to retain the images it fetches between
builds. These images are kept in `/var/lib/acbuild`. This results in a
better UX, as iterating on an acbuild script takes much less time when
the dependencies are not constantly re-downloaded.

The commands added to interact with the store are:
- **acbuild store fetch IMAGE**: fetches an image into the store
- **acbuild store rm IMAGE**: removes an image from the store
- **acbuild store list**: lists all images in the store, in the form of
  NAME:VERSION
- **acbuild store clear**: deletes all images in the store
