### PR TITLE
Workaround: install missing Virtualbox Guest Additions in Xenial

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,27 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$success_message = <<MESSAGE
+You must manually enable the shared folder in the Vagrantfile.
+Edit the 'config.vm.synced_folder' line and set 'disabled' to 'false',
+then run 'vagrant reload --provision' to reboot and mount the shared folder.
+We do apologize for the inconvenience. Upstream changes are pending
+to avoid this manual bootstrapping process in the future.
+MESSAGE
+
+$script = <<SCRIPT
+echo "Configuring shared folder under Ubuntu 16.04..."
+sudo apt-get --no-install-recommends install -y virtualbox-guest-utils
+if [[ ! -d /vagrant ]]; then
+echo "#{$success_message}" 1>&2 &&
+exit 1
+fi
+SCRIPT
+
 Vagrant.configure('2') do |config|
     # grab Ubuntu 16.04 official image
     config.vm.box = "ubuntu/xenial64" # Ubuntu 16.04
+    config.vm.synced_folder "./", "/vagrant", disabled: true
 
     # fix issues with slow dns http://serverfault.com/a/595010
     config.vm.provider :virtualbox do |vb, override|
@@ -9,6 +30,11 @@ Vagrant.configure('2') do |config|
         # add more ram, the default isn't enough for the build
         vb.customize ["modifyvm", :id, "--memory", "768"]
     end
+
+    # The /vagrant shared folder functionality is broken in Ubuntu 16.04, see:
+    # https://bugs.launchpad.net/cloud-images/+bug/1565985
+    # So let's handle the automagic ourselves.
+    config.vm.provision "shell", inline: $script
 
     # install Build Dependencies (GOLANG)
     config.vm.provision :shell, :privileged => false, :path => "scripts/vagrant-install-go.sh"


### PR DESCRIPTION
As originally noted in
https://github.com/appc/acbuild/issues/234#issuecomment-238365738, it appears
the script `scripts/vagrant-install-go.sh` intends to be executed via the
synced folder functionality of Virtualbox, which requires the Virtualbox Guest
Additions to be installed in the guest VM. As noted, this is missing from the
Xenial image (see bug https://bugs.launchpad.net/cloud-images/+bug/1565985).
This implements a workaround for this bug, and is a first step towards fixing
the Vagrant-based option for building `acbuild` (see
https://github.com/appc/acbuild/issues/234#issuecomment-238393500 for why this
is just the first step).

Fixes #234.
