### PR TITLE
enable ppc64le architecture

### DIFF
--- a/vendor/github.com/appc/spec/schema/types/labels.go
+++ b/vendor/github.com/appc/spec/schema/types/labels.go
@@ -21,7 +21,7 @@ import (
 )
 
 var ValidOSArch = map[string][]string{
-	"linux":   {"amd64", "i386", "aarch64", "aarch64_be", "armv6l", "armv7l", "armv7b"},
+	"linux":   {"amd64", "i386", "aarch64", "aarch64_be", "armv6l", "armv7l", "armv7b", "ppc64le"},
 	"freebsd": {"amd64", "i386", "arm"},
 	"darwin":  {"x86_64", "i386"},
 }


### PR DESCRIPTION
This just add ppc64le support for acbuild. Currently, it does
not support ppc64le architecture, failing with the following error:

begin: json: error calling MarshalJSON for type types.Labels: bad arch "ppc64le" for linux (must be one of: [amd64 i386 aarch64 aarch64_be armv6l armv7l armv7b])