### PR TITLE
Support HTTP Basic authentication when fetching dependencies

### DIFF
--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -15,6 +15,38 @@ In order to be able to run the command, all dependencies of the current ACI
 must be fetched. The first time `run` is called, the dependencies will be
 downloaded and expanded.
 
+### Authentication
+
+acbuild can use HTTP Basic authentication when fetching dependencies. To use
+authentication, specify a directory using the `--auth-config-dir` flag. By
+default acbuild will look in `auth.d`.
+
+acbuild looks for configuration files with a `.json` file name extension in the
+specified directory and its subdirectories. Each file is expected to contain
+two fields: `domains` and `credentials`.
+
+The `domains` field is an array of strings describing hosts for which the
+following credentials should be used. Each entry must consist of a host in a
+URL as specified by RFC 3986.
+
+The `credentials` field is a map with two keys - `user` and `password`. These
+should be the values needed for successful authentication with the given
+hosts.
+
+For example:
+
+`auth.d/coreos-basic.json`
+
+```
+{
+    "domains": ["coreos.com", "tectonic.com"],
+    "credentials": {
+        "user": "foo",
+        "password": "bar"
+    }
+}
+```
+
 ## Overlayfs
 
 acbuild utilizes overlayfs when running a command in an ACI with dependencies.

--- a/acbuild/run.go
+++ b/acbuild/run.go
@@ -26,10 +26,12 @@ import (
 )
 
 var (
-	insecure   = false
-	workingdir = ""
-	engineName = ""
-	cmdRun     = &cobra.Command{
+	insecure      = false
+	workingdir    = ""
+	engineName    = ""
+	authConfigDir = ""
+
+	cmdRun = &cobra.Command{
 		Use:     "run -- CMD [ARGS]",
 		Short:   "Run a command in an ACI",
 		Long:    "Run a given command in an ACI, and save the resulting container as a new ACI",
@@ -55,6 +57,7 @@ func init() {
 	cmdRun.Flags().BoolVar(&insecure, "insecure", false, "Allows fetching dependencies over http")
 	cmdRun.Flags().StringVar(&workingdir, "working-dir", "", "The working directory inside the container for this command")
 	cmdRun.Flags().StringVar(&engineName, "engine", "systemd-nspawn", "The engine used to run the command. Supported engines: "+engineList)
+	cmdRun.Flags().StringVar(&authConfigDir, "auth-config-dir", "auth.d", "Directory with authentication config file(s)")
 }
 
 func runRun(cmd *cobra.Command, args []string) (exit int) {
@@ -73,7 +76,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	err := newACBuild().Run(args, workingdir, insecure, engine)
+	err := newACBuild().Run(args, workingdir, insecure, engine, authConfigDir)
 
 	if err != nil {
 		stderr("run: %v", err)

--- a/lib/run.go
+++ b/lib/run.go
@@ -47,7 +47,7 @@ import (
 // changed to its value before running the given command.
 //
 // - runEngine:  The engine used to perform the execution of the command.
-func (a *ACBuild) Run(cmd []string, workingDir string, insecure bool, runEngine engine.Engine) (err error) {
+func (a *ACBuild) Run(cmd []string, workingDir string, insecure bool, runEngine engine.Engine, authConfigDir string) (err error) {
 	if err = a.lock(); err != nil {
 		return err
 	}
@@ -110,7 +110,7 @@ func (a *ACBuild) Run(cmd []string, workingDir string, insecure bool, runEngine 
 		}
 	}
 
-	deps, err := a.renderACI(insecure, a.Debug)
+	deps, err := a.renderACI(insecure, authConfigDir, a.Debug)
 	if err != nil {
 		return err
 	}
@@ -179,10 +179,16 @@ func supportsOverlay() bool {
 	return false
 }
 
-func (a *ACBuild) renderACI(insecure, debug bool) ([]string, error) {
+func (a *ACBuild) renderACI(insecure bool, authConfigDir string, debug bool) ([]string, error) {
+	authConfig, err := registry.ReadAuthConfig(authConfigDir)
+	if err != nil {
+		return nil, err
+	}
+
 	reg := registry.Registry{
 		DepStoreTarPath:      a.DepStoreTarPath,
 		DepStoreExpandedPath: a.DepStoreExpandedPath,
+		AuthConfig:           authConfig,
 		Insecure:             insecure,
 		Debug:                debug,
 	}

--- a/registry/auth-config.go
+++ b/registry/auth-config.go
@@ -1,0 +1,81 @@
+package registry
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+type HostHeaders map[string]http.Header
+
+type AuthConfig []AuthFile
+
+type AuthFile struct {
+	Domains     []string    `json:"domains"`
+	Credentials Credentials `json:"credentials"`
+}
+
+type Credentials struct {
+	User     string `json:"user"`
+	Password string `json:"password"`
+}
+
+func ReadAuthConfig(directory string) (*AuthConfig, error) {
+	authConfig := AuthConfig{}
+
+	err := filepath.Walk(directory, func(path string, file os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+
+		if !validAuthFile(file) {
+			return nil
+		}
+
+		jsonContents, err := ioutil.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("auth-config: %s", err)
+		}
+
+		authFile := AuthFile{}
+		err = json.Unmarshal(jsonContents, &authFile)
+		if err != nil {
+			return fmt.Errorf("auth-config: %s", err)
+		}
+
+		authConfig = append(authConfig, authFile)
+
+		return nil
+	})
+
+	return &authConfig, err
+}
+
+func validAuthFile(file os.FileInfo) bool {
+	if !file.Mode().IsRegular() {
+		return false
+	}
+
+	if filepath.Ext(file.Name()) != ".json" {
+		return false
+	}
+
+	return true
+}
+
+func (ac *AuthConfig) HostHeaders() HostHeaders {
+	hostHeaders := HostHeaders{}
+	for _, authFile := range *ac {
+		fakeRequest := http.Request{Header: http.Header{}}
+		fakeRequest.SetBasicAuth(authFile.Credentials.User, authFile.Credentials.Password)
+
+		for _, domain := range authFile.Domains {
+			hostHeaders[domain] = fakeRequest.Header
+		}
+	}
+
+	return hostHeaders
+}

--- a/registry/fetch.go
+++ b/registry/fetch.go
@@ -336,7 +336,7 @@ func (r Registry) discoverEndpoint(imageName types.ACIdentifier, labels types.La
 		insecure = discovery.InsecureHTTP
 	}
 
-	acis, attempts, err := discovery.DiscoverACIEndpoints(*app, nil, insecure, 0)
+	acis, attempts, err := discovery.DiscoverACIEndpoints(*app, r.AuthConfig.HostHeaders(), insecure, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -355,11 +355,15 @@ func (r Registry) discoverEndpoint(imageName types.ACIdentifier, labels types.La
 }
 
 func (r Registry) download(url, path, label string) error {
-	//TODO: auth
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return err
 	}
+
+	if header, ok := r.AuthConfig.HostHeaders()[req.URL.Host]; ok {
+		req.Header = header
+	}
+
 	transport := http.DefaultTransport
 	transport.(*http.Transport).Proxy = http.ProxyFromEnvironment
 	if r.Insecure {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -49,6 +49,7 @@ var (
 type Registry struct {
 	DepStoreTarPath      string
 	DepStoreExpandedPath string
+	AuthConfig           *AuthConfig
 	Insecure             bool
 	Debug                bool
 }


### PR DESCRIPTION
Hello!

I need to be able to supply HTTP Basic auth as part of the discovery process, so I modeled an implementation off of the `rkt` file format.

Can you take a look and let me know if this is along the lines of what you were thinking?

Thanks!