### PR TITLE
Vagrant on OS X tweaks

### DIFF
--- a/build
+++ b/build
@@ -32,5 +32,7 @@ fi
 
 echo "Building acbuild..."
 go build -o $GOBIN/acbuild -ldflags "${GLDFLAGS}" ${ACBUILD_BUILD_TAGS} ${REPO_PATH}/acbuild
-ln -f $GOBIN/acbuild $GOBIN/acbuild-script
-ln -f $GOBIN/acbuild $GOBIN/acbuild-chroot
+pushd "$GOBIN"
+ln -sf acbuild acbuild-script
+ln -sf acbuild acbuild-chroot
+popd

--- a/scripts/vagrant-install-acbuild.sh
+++ b/scripts/vagrant-install-acbuild.sh
@@ -11,5 +11,5 @@ curl -s -q -L -o rkt.tar.gz https://github.com/coreos/rkt/releases/download/v1.1
 tar xfv rkt.tar.gz
 sudo cp -v rkt-v1.1.0/rkt /usr/local/bin
 sudo cp -v rkt-v1.1.0/*.aci /usr/local/bin
-sudo groupadd rkt
+getent group rkt || sudo groupadd rkt
 sudo ./rkt-v1.1.0/scripts/setup-data-dir.sh

--- a/scripts/vagrant-install-go.sh
+++ b/scripts/vagrant-install-go.sh
@@ -3,7 +3,7 @@
 set -x
 
 export DEBIAN_FRONTEND=noninteractive
-VERSION=1.4.2
+VERSION=1.5.4
 OS=linux
 ARCH=amd64
 


### PR DESCRIPTION
Fixes a couple issues I ran into trying to build acbuild with Vagrant/VirtualBox on OS X.

* Hard links are not allowed on an OS X shared folder

  Fixes issue with building acbuild on Vagrant on OS X:
```
==> default: ln: failed to create hard link '/vagrant/bin/acbuild-script'
=> '/vagrant/bin/acbuild'
==> default: : Operation not permitted
```

* vagrant build uses go 1.5 (matches build-docker)
* Only attempt to add the group `rkt` if it doesn't currently exist (`vagrant provision` succeeds after initial provision)