### PR TITLE
Update clone destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Follow these steps to do so:
 1. Grab the source code for `acbuild` by `git clone`ing the source repository:
    ```
    cd ~
-   git clone https://github.com/containers/build
+   git clone https://github.com/containers/build acbuild
    ```
 
 2. Run the `build` script from the root source repository directory:


### PR DESCRIPTION
The instructions don't work as-is.  It's a simple matter, presumably the repo was formerly called "acbuild".  I think it makes more sense to clone it into a dir called `acbuild` than to update the rest of the instructions.