### PR TITLE
Fix clone destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ can quickly get you set up with a Linux VM that has both acbuild and rkt. The
 following steps will grab acbuild, set up the machine, and ssh into it.
 
 ```
-git clone https://github.com/containers/build
+git clone https://github.com/containers/build acbuild
 cd acbuild
 vagrant up
 vagrant ssh


### PR DESCRIPTION
Oops, looks like I missed the second `clone` command.  See 27cedb24a22fbe7354c2d0cdd281f0bfe80a665f for related change.