### PR TITLE
lib/end: print a warning to run as root when permission denied

### DIFF
--- a/lib/common.go
+++ b/lib/common.go
@@ -89,6 +89,15 @@ func (a *ACBuild) lock() error {
 
 	a.lockFile, err = os.OpenFile(a.LockPath, os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
+		switch err1 := err.(type) {
+		case *os.PathError:
+			switch err2 := err1.Err.(type) {
+			case syscall.Errno:
+				if err2 == syscall.EACCES {
+					err = fmt.Errorf("permission denied: please run this as a user with appropriate privileges\n")
+				}
+			}
+		}
 		return err
 	}
 

--- a/lib/end.go
+++ b/lib/end.go
@@ -15,7 +15,9 @@
 package lib
 
 import (
+	"fmt"
 	"os"
+	"syscall"
 
 	"github.com/containers/build/util"
 )
@@ -42,6 +44,15 @@ func (a *ACBuild) End() error {
 
 	err = os.RemoveAll(a.ContextPath)
 	if err != nil {
+		switch err1 := err.(type) {
+		case *os.PathError:
+			switch err2 := err1.Err.(type) {
+			case syscall.Errno:
+				if err2 == syscall.EACCES {
+					err = fmt.Errorf("permission denied: please run this as a user with appropriate privileges\n")
+				}
+			}
+		}
 		return err
 	}
 


### PR DESCRIPTION
When a subcommand attempts to grab a lock due to permission denied or
end fails to delete something due to permission denied, a warning will
now be printed advising the user to run the command as root.

Example:
```
derek@proton ~/go/src/github.com/containers/build> ./bin/acbuild end
you'll need to run this as a user with appropriate privileges
end: remove .acbuild/currentaci/rootfs/var/www/localhost/htdocs: permission denied
```

Fixes https://github.com/containers/build/issues/284