### PR TITLE
lib/run: better error output when dependency doesn't exist

### DIFF
--- a/lib/run.go
+++ b/lib/run.go
@@ -199,7 +199,12 @@ func (a *ACBuild) renderACI(insecure, debug bool) ([]string, error) {
 	var deplist []string
 	for _, dep := range man.Dependencies {
 		err := reg.FetchAndRender(dep.ImageName, dep.Labels, dep.Size)
-		if err != nil {
+		switch err {
+		case nil:
+		case registry.ErrNotFound:
+			l, _ := dep.Labels.Get("version")
+			return nil, fmt.Errorf("dependency %q doesn't appear to exist: %v", string(dep.ImageName)+":"+l, err)
+		default:
 			return nil, err
 		}
 

--- a/registry/fetch.go
+++ b/registry/fetch.go
@@ -386,6 +386,8 @@ func (r Registry) download(url, path, label string) error {
 	switch res.StatusCode {
 	case http.StatusOK:
 		break
+	case http.StatusNotFound:
+		return ErrNotFound
 	default:
 		return fmt.Errorf("bad HTTP status code: %d", res.StatusCode)
 	}


### PR DESCRIPTION
If fetching a dependency for a run command, and the registry returns a
404 error, intercept that and print a more user-friendly error saying
that the dependency doesn't exist.

Example:
```
derek@proton 1 ~/go/src/github.com/containers/build> sudo ./bin/acbuild run -- apk update
run: dependency "quay.io/coreos/alpine-sh:doesnt-exist" doesn't appear to exist: bad HTTP status code: 404
```

Fixes https://github.com/containers/build/issues/283