### PR TITLE
Handle host /etc/resolv.conf being a symlink

### DIFF
--- a/engine/chroot/chroot.go
+++ b/engine/chroot/chroot.go
@@ -22,7 +22,6 @@ import (
 	"github.com/containers/build/engine"
 	"github.com/coreos/rkt/pkg/fileutil"
 	"github.com/coreos/rkt/pkg/multicall"
-	"github.com/coreos/rkt/pkg/user"
 )
 
 type Engine struct{}
@@ -40,7 +39,7 @@ func (e Engine) Run(command string, args []string, environment map[string]string
 		if err != nil {
 			return err
 		}
-		err = fileutil.CopyTree("/etc/resolv.conf", resolvConfFile, user.NewBlankUidRange())
+		err = fileutil.CopyRegularFile("/etc/resolv.conf", resolvConfFile)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
`/etc/resolv.conf` can be a symlink (eg. Fedora 25), but the symlink likely won't resolve inside the chroot. Copy `/etc/resolv.conf` as regular file instead.

Previous behaviour:
```
$ sudo "PATH=$(pwd)/bin:$PATH" bin/acbuild begin --debug ./library-alpine-3.5.aci
Beginning build with ./library-alpine-3.5.aci
$ sudo "PATH=$(pwd)/bin:$PATH" bin/acbuild run --engine chroot -- \
  sh -c 'ls -la /etc/resolv.conf && cat /etc/resolv.conf'
lrwxrwxrwx    1 root     root            35 Mar  7 22:22 /etc/resolv.conf -> /var/run/NetworkManager/resolv.conf
cat: can't open '/etc/resolv.conf': No such file or directory
```

New behaviour:
```
$ sudo "PATH=$(pwd)/bin:$PATH" bin/acbuild run --engine chroot -- \
  sh -c 'ls -la /etc/resolv.conf && cat /etc/resolv.conf'
-rw-r--r--    1 root     root           123 Mar  9 01:01 /etc/resolv.conf
# Generated by NetworkManager
...
```


