### PR TITLE
oci/manifest: use actual ImageLayer media type

### DIFF
--- a/lib/oci/manifest.go
+++ b/lib/oci/manifest.go
@@ -246,7 +246,7 @@ func (i *Image) UpdateTopLayerHash(hashAlgo, newHash string, size int64) (string
 
 	layerDescriptor :=
 		ociImage.Descriptor{
-			MediaType: "MediaTypeImageLayer",
+			MediaType: ociImage.MediaTypeImageLayer,
 			Digest:    hashStr,
 			Size:      size,
 		}
@@ -272,7 +272,7 @@ func (i *Image) NewTopLayer(hashAlgo, newHash string, size int64) error {
 
 	layerDescriptor :=
 		ociImage.Descriptor{
-			MediaType: "MediaTypeImageLayer",
+			MediaType: ociImage.MediaTypeImageLayer,
 			Digest:    hashStr,
 			Size:      size,
 		}


### PR DESCRIPTION
This PR fixes a bug where the mediaType for layers was incorrectly set to "MediaTypeImageLayer" literal.