### PR TITLE
oci: fix blob-layer digest computation

### DIFF
--- a/lib/common.go
+++ b/lib/common.go
@@ -200,16 +200,16 @@ func (a *ACBuild) rehashAndStoreOCIBlob(targetPath string, newLayer bool) error 
 			tmpFile.Close()
 		}
 	}()
-	gzwriter := gzip.NewWriter(tmpFile)
+	combinedWriter := io.MultiWriter(hashWriter, tmpFile)
+
+	gzwriter := gzip.NewWriter(combinedWriter)
 	defer func() {
 		if !finishedWriting {
 			gzwriter.Close()
 		}
 	}()
 
-	combinedWriter := io.MultiWriter(hashWriter, gzwriter)
-
-	twriter := tar.NewWriter(combinedWriter)
+	twriter := tar.NewWriter(gzwriter)
 	defer func() {
 		if !finishedWriting {
 			twriter.Close()


### PR DESCRIPTION
This fixes blob-layer digests in OCI images, by performing digest
computation on the final gzip'd layers content as specified by
current image-spec.