### PR TITLE
fix node-build trap script

### DIFF
--- a/examples/nodejs/build-nodejs.sh
+++ b/examples/nodejs/build-nodejs.sh
@@ -10,7 +10,7 @@ fi
 acbuild --debug begin
 
 # In the event of the script exiting, end the build
-trap "{ export EXT=$?; acbuild --debug end && exit $EXT; }" EXIT
+trap '{ export EXT=$?; acbuild --debug end && exit $EXT; }' EXIT
 
 # Name the ACI
 acbuild --debug set-name example.com/nodejs


### PR DESCRIPTION
The variables are now expanded when the script is interpreted, rather than when the script is invoked. This causes the wrong status code to be propagated. This patch fixes that. Thanks!