### PR TITLE
write: print image id on successfull write;

### DIFF
--- a/acbuild/acbuild.go
+++ b/acbuild/acbuild.go
@@ -259,7 +259,7 @@ func runWrapper(cf func(cmd *cobra.Command, args []string) (exit int)) func(cmd 
 		dir, file := path.Split(aciToModify)
 		tmpFile := path.Join(dir, "."+file+".tmp")
 
-		err = a.Write(tmpFile, true)
+		_, err = a.Write(tmpFile, true)
 		if err != nil {
 			stderr("%v", err)
 			cmdExitCode = getErrorCode(err)

--- a/acbuild/write.go
+++ b/acbuild/write.go
@@ -56,12 +56,12 @@ func runWrite(cmd *cobra.Command, args []string) (exit int) {
 		stderr("%v", err)
 		return 1
 	}
-	err = a.Write(args[0], overwrite)
+	id, err := a.Write(args[0], overwrite)
 
 	if err != nil {
 		stderr("write: %v", err)
 		return getErrorCode(err)
 	}
-
+	stdout(id)
 	return 0
 }


### PR DESCRIPTION
solves #305

It currently doesn't implement an option to turn id generation on or off, but the hash is computed concurrently to the disk wirtes, so I do not think there will be an performance impact.