### PR TITLE
Store DiffIDs correctly in OCI config

### DIFF
--- a/lib/copy.go
+++ b/lib/copy.go
@@ -79,7 +79,7 @@ func (a *ACBuild) expandTopOCILayer() (string, error) {
 	var topLayerID string
 	switch ociMan := a.man.(type) {
 	case *oci.Image:
-		layerIDs := ociMan.GetLayerHashes()
+		layerIDs := ociMan.GetLayerDigests()
 		if len(layerIDs) > 0 {
 			topLayerID = layerIDs[len(layerIDs)-1]
 		}

--- a/lib/oci/manifest.go
+++ b/lib/oci/manifest.go
@@ -231,23 +231,24 @@ func (i *Image) Print(w io.Writer, prettyPrint, printConfig bool) error {
 	return nil
 }
 
-func (i *Image) UpdateTopLayerHash(hashAlgo, newHash string, size int64) (string, error) {
-	var oldTopLayerHash string
-	hashStr := hashAlgo + ":" + newHash
+func (i *Image) UpdateTopLayer(digestAlgo, layerDigest, diffId string, size int64) (string, error) {
+	var oldLayerDigest string
+	layerDigest = digestAlgo + ":" + layerDigest
+	diffId = digestAlgo + ":" + diffId
 	if len(i.config.RootFS.DiffIDs) == 0 {
 		i.config.RootFS = ociImage.RootFS{
 			Type:    "layers",
-			DiffIDs: []string{hashStr},
+			DiffIDs: []string{diffId},
 		}
 	} else {
-		oldTopLayerHash = i.config.RootFS.DiffIDs[len(i.config.RootFS.DiffIDs)-1]
-		i.config.RootFS.DiffIDs[len(i.config.RootFS.DiffIDs)-1] = hashStr
+		oldLayerDigest = i.config.RootFS.DiffIDs[len(i.config.RootFS.DiffIDs)-1]
+		i.config.RootFS.DiffIDs[len(i.config.RootFS.DiffIDs)-1] = diffId
 	}
 
 	layerDescriptor :=
 		ociImage.Descriptor{
 			MediaType: ociImage.MediaTypeImageLayer,
-			Digest:    hashStr,
+			Digest:    layerDigest,
 			Size:      size,
 		}
 	if len(i.manifest.Layers) == 0 {
@@ -256,24 +257,25 @@ func (i *Image) UpdateTopLayerHash(hashAlgo, newHash string, size int64) (string
 		i.manifest.Layers[len(i.manifest.Layers)-1] = layerDescriptor
 	}
 
-	return oldTopLayerHash, i.save()
+	return oldLayerDigest, i.save()
 }
 
-func (i *Image) NewTopLayer(hashAlgo, newHash string, size int64) error {
-	hashStr := hashAlgo + ":" + newHash
+func (i *Image) NewTopLayer(digestAlgo, layerDigest, diffId string, size int64) error {
+	layerDigest = digestAlgo + ":" + layerDigest
+	diffId = digestAlgo + ":" + diffId
 	if len(i.config.RootFS.DiffIDs) == 0 {
 		i.config.RootFS = ociImage.RootFS{
 			Type:    "layers",
-			DiffIDs: []string{hashStr},
+			DiffIDs: []string{diffId},
 		}
 	} else {
-		i.config.RootFS.DiffIDs = append(i.config.RootFS.DiffIDs, hashStr)
+		i.config.RootFS.DiffIDs = append(i.config.RootFS.DiffIDs, diffId)
 	}
 
 	layerDescriptor :=
 		ociImage.Descriptor{
 			MediaType: ociImage.MediaTypeImageLayer,
-			Digest:    hashStr,
+			Digest:    layerDigest,
 			Size:      size,
 		}
 	if len(i.manifest.Layers) == 0 {

--- a/lib/run.go
+++ b/lib/run.go
@@ -191,27 +191,27 @@ func (a *ACBuild) generateOverlayPathsAppC(insecure bool) ([]string, error) {
 }
 
 func (a *ACBuild) generateOverlayPathsOCI() ([]string, error) {
-	var layerIDs []string
+	var layerDigests []string
 	switch ociMan := a.man.(type) {
 	case *oci.Image:
-		layerIDs = ociMan.GetLayerHashes()
+		layerDigests = ociMan.GetLayerDigests()
 	default:
 		return nil, fmt.Errorf("internal error: mismatched manifest type and build mode???")
 	}
 
 	var layerPaths []string
-	if len(layerIDs) == 0 {
+	if len(layerDigests) == 0 {
 		layerPaths = []string{path.Join(a.OCIExpandedBlobsPath, "sha256", "new-layer")}
 		err := os.MkdirAll(layerPaths[0], 0755)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		err := util.OCIExtractLayers(layerIDs, a.CurrentImagePath, a.OCIExpandedBlobsPath)
+		err := util.OCIExtractLayers(layerDigests, a.CurrentImagePath, a.OCIExpandedBlobsPath)
 		if err != nil {
 			return nil, err
 		}
-		for _, layerID := range layerIDs {
+		for _, layerID := range layerDigests {
 			algo, hash, err := util.SplitOCILayerID(layerID)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Disable gzip compression for OCI image layers in order to get Docker to run it properly. If gzip compression is turned on, Docker complains about a layer checksum mismatch because it calculates the checksum after
decompressing it.

Here's how to reproduce it:
1. Build an OCI image (containing a trivial hello world application) and push it to Docker Hub using [skopeo](https://github.com/projectatomic/skopeo):
```
$ ./acbuild begin --build-mode=oci
$ ./acbuild copy hello /hello
$ ./acbuild set-exec /hello
$ ./acbuild write myimage.oci
$ mkdir myimage
$ tar xf myimage.oci -C myimage
$ ./skopeo copy oci:myimage docker://mwuertinger/oci-test
```
2. Trying to pull the image with Docker yields an error:
```
$ docker pull mwuertinger/oci-test
Using default tag: latest
latest: Pulling from mwuertinger/oci-test

d55c176aaf3d: Pull complete 
layers from manifest don't match image configuration
```

I traced this error back to https://github.com/moby/moby/blob/master/distribution/pull_v2.go#L638 where the calculated checksum of the downloaded layer is compared to the layer specified in the image manifest. As it turns out, Docker decompresses the layer before calculating the expected checksum which yields an unexpected result and the check fails.

This can be solved by skipping layer compression. However, I do not know whether this is a bug in Docker or in acbuild. Therefore I do not expect this pull request to get merged but see it more as a proof of concept of how it could work.