### PR TITLE
lib: show correct error when loadManifest fails

### DIFF
--- a/lib/common.go
+++ b/lib/common.go
@@ -106,8 +106,8 @@ func (a *ACBuild) loadManifest() error {
 		a.man, err = oci.LoadImage(a.CurrentImagePath)
 	}
 	if err != nil {
-		_, err := os.Stat(a.ContextPath)
-		if !os.IsNotExist(err) {
+		_, serr := os.Stat(a.ContextPath)
+		if !os.IsNotExist(serr) {
 			// If the context path exists, then this build was started and we
 			// shouldn't have failed. Let's error.
 			return fmt.Errorf("error loading manifest: %v\n", err)


### PR DESCRIPTION
The err value was accidentally getting overriden with the error from the
os.Stat call.