### PR TITLE
Improve shell script

### DIFF
--- a/Documentation/shell-scripts.md
+++ b/Documentation/shell-scripts.md
@@ -1,39 +1,40 @@
-# Bash scripts
+# Managing `acbuild` using shell scripting
 
-Bash scripting provides a common, simple, and well-known mechanism to drive
+Shell scripting provides a common, simple, and well-known mechanism to drive
 `acbuild`. A script template, below, is used for the examples in this
 repository. It makes working with acbuild a little nicer by exiting the script
 when it hits an error, and calling `acbuild end` whenever the script exits.
 
-Since the script leverages `bash` features, we open it by specifying execution
-in the bash shell, rather than just inheriting the user's `SHELL` environment.
+## More background
 
 Further, we set the `-e` option to bash to ensure that the entire script exits
 on the failure of any command. This gives us some atomicity, ensuring that
-either a complete and valid image is constructed, or none at all
+either a complete and valid image is constructed, or none at all.
 
 The `begin` line starts the build. If the build is to be started from an
 existing image, this line will be different.
 
 The rest of the script is concerned with cleanup and error handling. The
-`acbuildend` function is interesting, as it serves as a simple "catch" mechanism
+`acbuildend` function is interesting, as it serves as a simple ‘catch’ mechanism
 for the script, called on a trap triggered by either reaching the script's end,
 or by a non-zero return value from any command in the script. `acibuildend`
 stores the last command's exit code, then calls `acbuild --debug end` to
 terminate the build, passing the exit code, if any, through the script exit, to
 help with troubleshooting.
 
-```bash
-#!/usr/bin/env bash
+## The script
+
+```sh
+#!/bin/sh
 set -e
-
-acbuildend () {
-    export EXIT=$?;
-    acbuild --debug end && exit $EXIT;
+acbuild_end() {
+    set +e
+    status=$?
+    acbuild end
+    set -e
+    return "$status"
 }
+trap acbuild_end INT TERM EXIT
 
-acbuild --debug begin
-trap acbuildend EXIT
-
-# User entered acbuild commands go here
+# Expand here ...
 ```


### PR DESCRIPTION
* Use a POSIX-compatible shell script and remove references to Bash.
* More complete handling of corner cases (e.g. failing `acbuild end`, termination signal, etc.)
* Mark tutorial-style info as extra background section.